### PR TITLE
Enable NSEL and PCAP support in Docker images

### DIFF
--- a/docker/nfdump/nfdump.dockerfile
+++ b/docker/nfdump/nfdump.dockerfile
@@ -20,7 +20,7 @@ WORKDIR /tmp
 
 ## Install OS dependencies
 ADD https://github.com/phaag/nfdump/archive/v${NFDUMP_VERSION}.tar.gz /tmp
-RUN apk add --no-cache bzip2-dev curl libtool
+RUN apk add --no-cache bzip2-dev curl libtool libpcap libpcap-dev
 RUN apk add --no-cache --virtual build-deps autoconf automake m4 pkgconfig make g++ flex byacc
 
 #Build
@@ -28,7 +28,7 @@ RUN  \
     tar xfz v${NFDUMP_VERSION}.tar.gz  \
     && cd /tmp/nfdump-${NFDUMP_VERSION} \
     && ./autogen.sh  \
-    && ./configure  \
+    && ./configure --enable-nsel --enable-nfpcapd \
     && make  \
     && cd /tmp/nfdump-${NFDUMP_VERSION} && make install  \
     && cd .. \

--- a/docker/php/php.dockerfile
+++ b/docker/php/php.dockerfile
@@ -42,7 +42,9 @@ RUN apk add --no-cache \
     libpq-dev \
     libtool \
     supervisor \
-    bzip2-dev
+    bzip2-dev \
+    libpcap \
+    libpcap-dev
 
 RUN docker-php-ext-install pgsql pdo pdo_pgsql mbstring exif zip soap pcntl bcmath curl zip opcache
 
@@ -68,7 +70,7 @@ RUN  \
     tar xfz v${NFDUMP_VERSION}.tar.gz  \
     && cd /tmp/nfdump-${NFDUMP_VERSION} \
     && ./autogen.sh  \
-    && ./configure  \
+    && ./configure --enable-nsel --enable-nfpcapd \
     && make  \
     && cd /tmp/nfdump-${NFDUMP_VERSION} && make install  \
     && cd .. \


### PR DESCRIPTION
## Summary
- build nfdump with NSEL and nfpcapd support
- add libpcap libraries to PHP and nfdump images

## Testing
- `composer install`
- `./vendor/bin/phpunit` *(fails: Test directory "tests/Unit" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ba00cf63b08332964d33102bc60f09